### PR TITLE
Fix README by removing redundant yarn section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@ pnpm add automatic1111-provider
 
 # npm
 npm install automatic1111-provider
-
-# yarn
-npm install automatic1111-provider
 ```
 
 ## Provider Instance


### PR DESCRIPTION
Removed duplicate npm installation instructions for yarn.